### PR TITLE
Prevent multiple React root creation in development

### DIFF
--- a/client/main.tsx
+++ b/client/main.tsx
@@ -174,4 +174,13 @@ const App = () => (
   </QueryClientProvider>
 );
 
-createRoot(document.getElementById("root")!).render(<App />);
+const container = document.getElementById("root")!;
+
+// Prevent multiple root creation in development
+if (!container._reactRoot) {
+  const root = createRoot(container);
+  container._reactRoot = root;
+  root.render(<App />);
+} else {
+  container._reactRoot.render(<App />);
+}

--- a/client/main.tsx
+++ b/client/main.tsx
@@ -177,10 +177,10 @@ const App = () => (
 const container = document.getElementById("root")!;
 
 // Prevent multiple root creation in development
-if (!container._reactRoot) {
+if (!(container as any)._reactRoot) {
   const root = createRoot(container);
-  container._reactRoot = root;
+  (container as any)._reactRoot = root;
   root.render(<App />);
 } else {
-  container._reactRoot.render(<App />);
+  (container as any)._reactRoot.render(<App />);
 }

--- a/client/vite-env.d.ts
+++ b/client/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+declare global {
+  interface Element {
+    _reactRoot?: import("react-dom/client").Root;
+  }
+}

--- a/client/vite-env.d.ts
+++ b/client/vite-env.d.ts
@@ -1,7 +1,1 @@
 /// <reference types="vite/client" />
-
-declare global {
-  interface Element {
-    _reactRoot?: import("react-dom/client").Root;
-  }
-}


### PR DESCRIPTION
Adds a check to prevent creating multiple React roots on the same container element during development.

Changes:
- Store the root instance on the container element as `_reactRoot`
- Check if a root already exists before creating a new one
- Reuse existing root for subsequent renders if it exists

This prevents potential issues with multiple root instances being created on the same DOM element.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/05c3a7f9098343fb87cb4d876edfa155/pixel-haven)

👀 [Preview Link](https://05c3a7f9098343fb87cb4d876edfa155-pixel-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>05c3a7f9098343fb87cb4d876edfa155</projectId>-->
<!--<branchName>pixel-haven</branchName>-->